### PR TITLE
refactor(metrics): remove redundant scraping metrics

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"time"
-
 	"github.com/caicloud/nirvana/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -14,36 +12,18 @@ const (
 
 // Exporter collects events and convert to metrics. It implements prometheus.Collector.
 type Exporter struct {
-	store           *EventStore
-	duration, error prometheus.Gauge
-	totalScrapes    prometheus.Counter
-	up              prometheus.Gauge
+	store *EventStore
 }
 
 // NewExporter return a new event exporter
 func NewExporter(store *EventStore) *Exporter {
 	return &Exporter{
 		store: store,
-		duration: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "last_scrape_duration_seconds",
-			Help: "Duration of the last scrape of metrics from event store.",
-		}),
-		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "scrapes_total",
-			Help: "Total number of times event store was scraped for metrics.",
-		}),
-		error: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "last_scrape_error",
-			Help: "Whether the last scrape of metrics from event store resulted in an error (1 for error, 0 for success).",
-		}),
 	}
 }
 
 // Collect implements prometheus.Collector.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	ch <- e.duration
-	ch <- e.totalScrapes
-	ch <- e.error
 	e.scrape(ch)
 	return
 }
@@ -65,17 +45,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
-	e.totalScrapes.Inc()
-	var err error
-	defer func(begun time.Time) {
-		e.duration.Set(time.Since(begun).Seconds())
-		if err == nil {
-			e.error.Set(0)
-		} else {
-			e.error.Set(1)
-		}
-	}(time.Now())
-	if err = e.store.Scrap(ch); err != nil {
+	if err := e.store.Scrap(ch); err != nil {
 		log.Errorln("Error scraping for events:", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Removed the following metrics:

 - last_scrape_duration_seconds
 - scrapes_total
 - last_scrape_error
 - up

These metrics are redundant since Prometheus would [automatically generate similar metrics](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series) for each instance anyway.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
