### PR TITLE
chore(make): remove internal dependency from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 #   make              - default to 'build' target
 #   make lint         - code analysis with golangci-lint
 #   make test         - run unit test
-#   make build        - build binary in a Golang container
+#   make build        - alias for `build-local` target
 #   make build-local  - build local binary
+#   make build-linux  - build amd64 Linux binary
 #   make container    - build container
 #   make push         - push container
 #   make clean        - clean up
@@ -31,10 +32,10 @@ export SHELLOPTS := errexit
 export GOFLAGS := -mod=vendor
 
 # this is not a public registry; change it to your own
-REGISTRY ?= cargo.dev.caicloud.xyz/release
-BASE_REGISTRY ?= cargo.caicloud.xyz/library
+REGISTRY ?= caicloud/
+BASE_REGISTRY ?=
 
-ARCH ?= amd64
+ARCH ?=
 GO_VERSION ?= 1.13
 
 CPUS ?= $(shell /bin/bash hack/read_cpus_available.sh)
@@ -73,7 +74,7 @@ build-linux:
 	  -e CGO_ENABLED=0																              \
 	  -e GOFLAGS=$(GOFLAGS)   	                                                       \
 	  -e SHELLOPTS=$(SHELLOPTS)                                                        \
-	  $(BASE_REGISTRY)/golang:$(GO_VERSION)                                            \
+	  $(BASE_REGISTRY)golang:$(GO_VERSION)                                            \
 	    /bin/bash -c '                                    								\
 	      	go build -i -v -o $(OUTPUT_DIR)/event_exporter -p $(CPUS)			\
           		 -ldflags "-s -w 										        \
@@ -85,11 +86,11 @@ build-linux:
 
 container: build-linux
 	@echo ">> building image"
-	@docker build -t $(REGISTRY)/event-exporter:$(VERSION) --label $(DOCKER_LABELS)  -f $(BUILD_DIR)/Dockerfile .
+	@docker build -t $(REGISTRY)event-exporter:$(VERSION) --label $(DOCKER_LABELS)  -f $(BUILD_DIR)/Dockerfile .
 
 push: container
 	@echo ">> pushing image"
-	@docker push $(REGISTRY)/event-exporter:$(VERSION)
+	@docker push $(REGISTRY)event-exporter:$(VERSION)
 
 lint: $(GOLANGCI_LINT)
 	@echo ">> running golangci-lint"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Remove internal dependency (registry, image) from the Makefile so that people not from Caicloud can use it as is.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @seymourtang 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
