### PR TITLE
Update Docker image to use scratch base

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,23 @@
-FROM debian:stretch-slim
+FROM golang:1.13-alpine as builder
+
+ENV USER=event_exporter
+ENV UID=10001
+RUN adduser \
+		--disabled-password \
+		--gecos "" \
+		--home "/nonexistent" \
+		--shell "/sbin/nologin" \
+		--no-create-home \
+		--uid "${UID}" \
+		"${USER}" && \
+	apk update && apk add --no-cache git ca-certificates gcc
+
+FROM scratch
 
 COPY bin/event_exporter /
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 USER nobody
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-USER nobody
+USER event-exporter
 
 ENTRYPOINT ["/event_exporter"]
 

--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -45,6 +45,9 @@ spec:
       labels:
         app: event-exporter
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
       containers:
         - name: event-exporter
           image: 'caicloud/event-exporter:v1.0.0'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caicloud/event_exporter
 
-go 1.13
+go 1.17
 
 require (
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caicloud/event_exporter
 
-go 1.17
+go 1.13
 
 require (
 	github.com/imdario/mergo v0.3.11 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

There are a number of vulnerabilities in the current image `v1.0.0`, this PR should fix that permanently going forwards by using a `scratch` base which only includes the static binary of the application, user info and CAs.

**Release note**:

```release-note
1. Update Dockerfile to use `scratch` base to avoid having vulnerabilities in the root filesystem.
```
